### PR TITLE
Create Angular tic-tac-toe web app (standalone, mobile-friendly, GH Pages ready)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+/bazel-out
+
+# dependencies
+/node_modules
+
+# profiling files
+chrome-profiler-events*.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# misc
+/.angular/cache
+.sass-cache/
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+pnpm-debug.log
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Tic-Tac-Toe (Angular)
+
+スマホでも遊べる、フロントエンドのみの三目並べアプリです。  
+先手 (`X`)・後手 (`O`) はどちらも人間が操作します。
+
+## ローカル実行
+
+```bash
+npm install
+npm start
+```
+
+## GitHub Pages デプロイ
+
+1. リポジトリ名を `tic-tac-toe` にする（base-hrefに使用）。
+2. 本番ビルドを実行。
+
+```bash
+npm run build:gh-pages
+```
+
+3. 生成された `dist/tic-tac-toe/browser` の中身を `gh-pages` ブランチへ配置して公開。
+
+GitHub Actionsを使う場合は、`dist/tic-tac-toe/browser` を Pages Artifact としてアップロードしてください。

--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "tic-tac-toe": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/tic-tac-toe",
+            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "public"
+              }
+            ],
+            "styles": [
+              "src/styles.scss"
+            ]
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "tic-tac-toe:build:production"
+            },
+            "development": {
+              "buildTarget": "tic-tac-toe:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
+            "tsConfig": "tsconfig.spec.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "public"
+              }
+            ],
+            "styles": [
+              "src/styles.scss"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "tic-tac-toe",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test",
+    "build:gh-pages": "ng build --configuration production --base-href /tic-tac-toe/"
+  },
+  "dependencies": {
+    "@angular/animations": "^19.0.0",
+    "@angular/common": "^19.0.0",
+    "@angular/compiler": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/forms": "^19.0.0",
+    "@angular/platform-browser": "^19.0.0",
+    "@angular/platform-browser-dynamic": "^19.0.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.15.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/cli": "^19.0.0",
+    "@angular/compiler-cli": "^19.0.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.4.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.6.2"
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,24 @@
+<main class="container">
+  <h1>三目並べ</h1>
+  <p class="subtitle">先手・後手ともに人間プレイヤーで対戦</p>
+
+  <section class="status" [ngClass]="{ finished: winner !== null }">
+    {{ statusText }}
+  </section>
+
+  <section class="board" aria-label="tic tac toe board">
+    @for (cell of board; track $index) {
+      <button
+        class="cell"
+        [ngClass]="{ x: cell === 'X', o: cell === 'O' }"
+        (click)="play($index)"
+        [disabled]="cell !== null || winner !== null"
+        [attr.aria-label]="'マス ' + ($index + 1)"
+      >
+        {{ cell }}
+      </button>
+    }
+  </section>
+
+  <button class="reset" type="button" (click)="reset()">リセット</button>
+</main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,90 @@
+:host {
+  display: block;
+  min-height: 100dvh;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: #e2e8f0;
+}
+
+.container {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 2rem;
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.5rem, 5vw, 2rem);
+}
+
+.subtitle {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+}
+
+.status {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.status.finished {
+  border-color: #f59e0b;
+  color: #fcd34d;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(80px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.cell {
+  width: 100%;
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 0.8rem;
+  background: #f8fafc;
+  color: #0f172a;
+  font-size: clamp(2rem, 9vw, 3rem);
+  font-weight: 700;
+}
+
+.cell:disabled {
+  opacity: 1;
+}
+
+.cell.x {
+  color: #2563eb;
+}
+
+.cell.o {
+  color: #dc2626;
+}
+
+.reset {
+  width: 100%;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #22c55e;
+  color: #052e16;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+@media (max-width: 360px) {
+  .container {
+    padding-inline: 0.75rem;
+  }
+
+  .board {
+    gap: 0.5rem;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,71 @@
+import { Component } from '@angular/core';
+import { NgClass } from '@angular/common';
+
+type Player = 'X' | 'O';
+type Cell = Player | null;
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [NgClass],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss'
+})
+export class AppComponent {
+  protected board: Cell[] = Array(9).fill(null);
+  protected currentPlayer: Player = 'X';
+  protected winner: Player | 'DRAW' | null = null;
+
+  protected get statusText(): string {
+    if (this.winner === 'DRAW') {
+      return '引き分けです';
+    }
+
+    if (this.winner) {
+      return `勝者: ${this.winner}`;
+    }
+
+    return `現在の手番: ${this.currentPlayer}`;
+  }
+
+  protected play(index: number): void {
+    if (this.board[index] || this.winner) {
+      return;
+    }
+
+    this.board[index] = this.currentPlayer;
+
+    const winningCombos = [
+      [0, 1, 2],
+      [3, 4, 5],
+      [6, 7, 8],
+      [0, 3, 6],
+      [1, 4, 7],
+      [2, 5, 8],
+      [0, 4, 8],
+      [2, 4, 6]
+    ];
+
+    const hasWinner = winningCombos.some(([a, b, c]) =>
+      this.board[a] && this.board[a] === this.board[b] && this.board[b] === this.board[c]
+    );
+
+    if (hasWinner) {
+      this.winner = this.currentPlayer;
+      return;
+    }
+
+    if (this.board.every((cell) => cell !== null)) {
+      this.winner = 'DRAW';
+      return;
+    }
+
+    this.currentPlayer = this.currentPlayer === 'X' ? 'O' : 'X';
+  }
+
+  protected reset(): void {
+    this.board = Array(9).fill(null);
+    this.currentPlayer = 'X';
+    this.winner = null;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>三目並べ</title>
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#0f172a">
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent).catch((err) => console.error(err));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,16 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, sans-serif;
+  background: #0f172a;
+}
+
+button {
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "useDefineForClassFields": false,
+    "lib": [
+      "ES2022",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- 提供された要件に基づき、バックエンド不要で単体動作するモバイル対応の三目並べ（先手/後手とも人間操作）をAngularで実装してGitHub Pagesへデプロイ可能にするため。 

### Description
- 新規にAngularスタイルのプロジェクト構成とビルド設定を追加し、`package.json`に`start`/`build`/`build:gh-pages`などのスクリプトを設定しました。 
- ゲーム本体は`src/app/app.component.ts`に実装し、9マスのボード、手番切替、勝利/引き分け判定、`reset()` を含むゲームロジックを追加しました。 
- UIテンプレートを`src/app/app.component.html`に、レスポンシブでタップに配慮したスタイルを`src/app/app.component.scss`と`src/styles.scss`に実装してスマホでの利用性を確保しました。 
- `angular.json`/`tsconfig*.json`/`src/index.html`などビルドと型チェック用の設定ファイルと、導入・デプロイ手順を記した`README.md`を追加しました。 

### Testing
- `npm install`（依存関係の取得）を実行しましたが、この環境ではnpmレジストリへのアクセスが `403 Forbidden` となり依存パッケージのインストールに失敗しました。 
- 依存のインストールができなかったため、`npm start`/`ng build`/`npm run build:gh-pages`やユニットテスト（`npm test`）は実行していません。 
- 自動テストは含めておらず、ビルドとブラウザでの動作確認は依存インストール後のローカル環境での実行を想定しています (`npm install` → `npm start` / `npm run build:gh-pages`)。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993daef5b0483249db8ad348177c9a2)