### PR TITLE
Add GitHub Actions workflow to deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build app for GitHub Pages
+        run: npm run build:gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/tic-tac-toe/browser
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ npm start
 
 ## GitHub Pages デプロイ
 
-1. リポジトリ名を `tic-tac-toe` にする（base-hrefに使用）。
-2. 本番ビルドを実行。
+このリポジトリには、`main` ブランチへ push すると自動で GitHub Pages へデプロイする CI (`.github/workflows/deploy.yml`) を追加しています。
+
+### 初回に必要な GitHub 設定
+
+1. GitHub の **Settings > Pages > Build and deployment** を開く
+2. **Source** を `GitHub Actions` に設定する
+
+### ローカルでデプロイ用ビルドだけ確認する場合
 
 ```bash
 npm run build:gh-pages
 ```
 
-3. 生成された `dist/tic-tac-toe/browser` の中身を `gh-pages` ブランチへ配置して公開。
-
-GitHub Actionsを使う場合は、`dist/tic-tac-toe/browser` を Pages Artifact としてアップロードしてください。
+GitHub Actions では `dist/tic-tac-toe/browser` を Pages Artifact としてアップロードして公開します。


### PR DESCRIPTION
### Motivation

- Enable automated CI deployment of the Angular app to GitHub Pages on `main` pushes and via manual run (`workflow_dispatch`).

### Description

- Add `.github/workflows/deploy.yml` which sets up Node.js, runs `npm ci`, executes `npm test`, runs `npm run build:gh-pages`, configures Pages, uploads `dist/tic-tac-toe/browser` as a Pages artifact, and deploys with `actions/deploy-pages@v4`.
- Trigger the workflow on `push` to `main` and on `workflow_dispatch`, and give the workflow the necessary `pages` and `id-token` permissions.
- Update `README.md` to document that CI will deploy via GitHub Actions and to instruct users to set Pages `Source` to `GitHub Actions` and how to run the local build with `npm run build:gh-pages`.

### Testing

- Ran `npm ci` locally and dependency installation completed successfully.
- Ran `npm test` and the Jest suite passed (`3 tests, 1 suite` passed).
- Ran `npm run build:gh-pages` and the production build completed with output placed at `dist/tic-tac-toe`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e3281c548324a31684b48e8fd492)