### PR TITLE
main向けPRマージ時にもデプロイワークフローを起動するよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
 
 permissions:
@@ -17,6 +22,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation
- `main` ブランチへのPRがマージされたタイミングでも GitHub Pages へのデプロイワークフローを起動できるようにするため。 

### Description
- `.github/workflows/deploy.yml` に `pull_request` トリガー（`branches: [main]`・`types: [closed]`）を追加し、`build` ジョブに `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true` 条件を設定してPRクローズ時はマージ済みの場合のみビルドを実行するようにしました。 

### Testing
- `npm test -- --watch=false` を実行し、テストスイートはすべて成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69946352ff4c832494d48b48bb4da3b7)