### PR TITLE
デプロイワークフローのトリガーブランチをmasterに修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
     types:
       - closed
   workflow_dispatch:


### PR DESCRIPTION
### Motivation
- リポジトリのデフォルトブランチが`master`のため、ワークフローが`main`をトリガーしても期待通りに動作しない可能性がありました。

### Description
- `.github/workflows/deploy.yml`の`push.branches`と`pull_request.branches`で指定されていた`main`を`master`に置き換えました。

### Testing
- `git diff --check && git status --short`、`git show --stat --oneline -1`および`nl -ba .github/workflows/deploy.yml`で変更を確認し、期待どおり`master`に置き換わっていることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699466bde7488324ac3450980ba49d73)