### PR TITLE
gh-pages への書き込みワークフローを直列化して push 競合を防止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: gh-pages-production
-  cancel-in-progress: true
+  group: gh-pages-writer
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,8 +15,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: gh-pages-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: gh-pages-writer
+  cancel-in-progress: false
 
 jobs:
   preview:


### PR DESCRIPTION
### Motivation
- 本番デプロイと PR プレビューが別々の `concurrency` グループで並行して `gh-pages` へ `git push` するため、non-fast-forward による push 失敗が断続的に発生していたため。 

### Description
- `.github/workflows/deploy.yml` の `concurrency.group` を `gh-pages-writer` に変更し `cancel-in-progress` を `false` に設定しました。 
- `.github/workflows/pr-preview.yml` も同様に `concurrency.group` を `gh-pages-writer` に統一し `cancel-in-progress` を `false` に設定しました。 
- 対象ファイルは ` .github/workflows/deploy.yml` と `.github/workflows/pr-preview.yml` です。 

### Testing
- `npm test -- --watch=false` を実行し全テストが通過することを確認しました（テストは成功しました）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699474fde6888324aefdc792cb9a9baf)