### PR TITLE
テスト安定性修正: Q学習トレーニングテストのエピソード数を調整

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -58,6 +58,7 @@ describe('AppComponent', () => {
 
   it('should train q-learning from agent tab', fakeAsync(() => {
     const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -65,6 +66,8 @@ describe('AppComponent', () => {
 
     (tabs[1] as HTMLButtonElement).click();
     fixture.detectChanges();
+
+    app.trainingConfig.episodes = 100;
 
     const trainButton = compiled.querySelector('.train') as HTMLButtonElement;
     trainButton.click();


### PR DESCRIPTION
### Motivation
- `should train q-learning from agent tab` テストがデフォルトの大量エピソードで不安定になっており、`tick(1000)` がすべてのマクロタスクを確実にフラッシュできないため安定化が必要でした。

### Description
- `src/app/app.component.spec.ts` の該当テストで `fixture.componentInstance` を `app` として参照できるようにしました（`fixture.componentInstance`）。
- 学習開始前に `app.trainingConfig.episodes = 100` を追加して、1チャンクで学習が完了するように調整しました（`app.trainingConfig.episodes = 100`）。
- テスト内の進行は従来通り `tick(1000)` を使用して動作検証しています（`tick(1000)`）。

### Testing
- 自動テストを `npm test -- --watch=false --runInBand` で実行し、全テストスイートが成功しました。 
- 結果は `6` テストスイート / `18` テスト がすべてパスしました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a90652648324a8ae22f93c1f2a8d)