### PR TITLE
オーバーレイ補助にミニマックスとQ学習を追加

### DIFF
--- a/src/app/agents/minimax-agent.ts
+++ b/src/app/agents/minimax-agent.ts
@@ -15,6 +15,21 @@ const scoreByWinner = (winner: Winner, player: Player): number => {
 };
 
 export class MinimaxAgent implements TicTacToeAgent {
+  evaluateMoveWinRates(state: GameState, player: Player): Map<number, number> {
+    const availableCells = getAvailableCells(state.board);
+    const winRateByCell = new Map<number, number>();
+
+    for (const cellIndex of availableCells) {
+      const nextBoard = [...state.board];
+      nextBoard[cellIndex] = player;
+
+      const score = this.minimax(nextBoard, nextPlayer(player), player);
+      winRateByCell.set(cellIndex, (score + 1) / 2);
+    }
+
+    return winRateByCell;
+  }
+
   pickMove(state: GameState, player: Player): number {
     const availableCells = getAvailableCells(state.board);
     const bestMoves: number[] = [];

--- a/src/app/agents/q-learning-agent.ts
+++ b/src/app/agents/q-learning-agent.ts
@@ -18,6 +18,14 @@ class MathRandomSource implements RandomSource {
 }
 
 export class QLearningAgent implements TicTacToeAgent {
+  evaluateMoveWinRates(state: GameState, player: Player): Map<number, number> {
+    const availableCells = getAvailableCells(state.board);
+    const stateKey = this.stateEncoder.encode(state.board, player);
+    const qValues = this.valueTable.getQValues(stateKey);
+
+    return new Map(availableCells.map((index) => [index, this.normalizeQValue(qValues[index])]));
+  }
+
   private readonly valueTable = new QLearningValueTable();
   private readonly stateEncoder = new QLearningStateEncoder();
   private readonly reward = new QLearningReward();
@@ -58,6 +66,14 @@ export class QLearningAgent implements TicTacToeAgent {
     }
 
     return epsilon;
+  }
+
+  private normalizeQValue(value: number): number {
+    return this.clamp((value + 1) / 2, 0, 1);
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
   }
 
   private normalizeConfig(config: QLearningTrainingConfig): ValidatedTrainingConfig {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -50,8 +50,10 @@
       <div class="overlay-assistant">
         <span class="overlay-assistant-label">オーバーレイ補助</span>
         <div class="overlay-assistant-buttons">
-          <button type="button" class="agent-toggle" [ngClass]="{ active: monteCarloOverlayAssistant === 'OFF' }" (click)="setMonteCarloOverlayAssistant('OFF')">オフ</button>
-          <button type="button" class="agent-toggle" [ngClass]="{ active: monteCarloOverlayAssistant === 'MONTE_CARLO' }" (click)="setMonteCarloOverlayAssistant('MONTE_CARLO')">モンテカルロ</button>
+          <button type="button" class="agent-toggle" [ngClass]="{ active: overlayAssistant === 'OFF' }" (click)="setOverlayAssistant('OFF')">オフ</button>
+          <button type="button" class="agent-toggle" [ngClass]="{ active: overlayAssistant === 'MONTE_CARLO' }" (click)="setOverlayAssistant('MONTE_CARLO')">モンテカルロ</button>
+          <button type="button" class="agent-toggle" [ngClass]="{ active: overlayAssistant === 'MINIMAX' }" (click)="setOverlayAssistant('MINIMAX')">ミニマックス</button>
+          <button type="button" class="agent-toggle" [ngClass]="{ active: overlayAssistant === 'Q_LEARNING' }" (click)="setOverlayAssistant('Q_LEARNING')">Q学習</button>
         </div>
       </div>
     </section>
@@ -60,8 +62,8 @@
       {{ statusText }}
     </section>
 
-    @if (showMonteCarloOverlay) {
-      <p class="overlay-status">{{ monteCarloOverlayStatusText }}</p>
+    @if (showOverlay) {
+      <p class="overlay-status">{{ overlayStatusText }}</p>
     }
 
     <section class="board" aria-label="tic tac toe board">
@@ -74,7 +76,7 @@
           [attr.aria-label]="'マス ' + ($index + 1)"
         >
           {{ cell }}
-          @if (showMonteCarloOverlay && overlayWinRate($index) !== null && cell === null) {
+          @if (showOverlay && overlayWinRate($index) !== null && cell === null) {
             <span class="overlay-rate">{{ overlayWinRate($index) | number: '1.0-0' }}%</span>
           }
         </button>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -91,7 +91,7 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
 
-    app.setMonteCarloOverlayAssistant('MONTE_CARLO');
+    app.setOverlayAssistant('MONTE_CARLO');
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -101,12 +101,12 @@ describe('AppComponent', () => {
     randomSpy.mockRestore();
   });
 
-  it('should keep monte carlo overlay visible after switching turn', () => {
+  it('should keep overlay visible after switching turn', () => {
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
 
-    app.setMonteCarloOverlayAssistant('MONTE_CARLO');
+    app.setOverlayAssistant('MONTE_CARLO');
     app.play(0);
     fixture.detectChanges();
 
@@ -116,6 +116,31 @@ describe('AppComponent', () => {
     expect(compiled.querySelector('.overlay-status')?.textContent).toContain('O 視点');
 
     randomSpy.mockRestore();
+  });
+
+
+  it('should show minimax overlay when overlay assistant is minimax', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+
+    app.setOverlayAssistant('MINIMAX');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelectorAll('.overlay-rate').length).toBeGreaterThan(0);
+    expect(compiled.querySelector('.overlay-status')?.textContent).toContain('ミニマックス');
+  });
+
+  it('should show q-learning overlay when overlay assistant is q-learning', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+
+    app.setOverlayAssistant('Q_LEARNING');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelectorAll('.overlay-rate').length).toBeGreaterThan(0);
+    expect(compiled.querySelector('.overlay-status')?.textContent).toContain('Q学習');
   });
 
   it('should auto play when random agent turn starts after a short delay', fakeAsync(() => {


### PR DESCRIPTION
### Motivation
- オーバーレイ補助をモンテカルロ以外でも使えるようにして、局面評価の視覚化手段を増やすため。 
- ミニマックスや学習済みQ値の評価をプレイ画面で確認できるようにすることで、デバッグや学習状況の可視化を容易にするため。

### Description
- `AppComponent` のオーバーレイ管理を `overlayAssistant`（`'OFF' | 'MONTE_CARLO' | 'MINIMAX' | 'Q_LEARNING'`）に統一し、汎用的な `updateOverlay()` と表示用プロパティ `showOverlay` / `overlayStatusText` を導入しました（`src/app/app.component.ts`）。
- プレイ画面のUIを更新してオーバーレイ選択肢に `ミニマックス` と `Q学習` を追加し、テンプレート内で汎用プロパティを参照するように変更しました（`src/app/app.component.html`）。
- `MinimaxAgent` に `evaluateMoveWinRates()` を追加し、ミニマックスの評価（-1〜1）を0〜1に正規化して返すようにしました（`src/app/agents/minimax-agent.ts`）。
- `QLearningAgent` に `evaluateMoveWinRates()` を追加し、状態のQ値を0〜1に正規化して返すユーティリティ（`normalizeQValue` / `clamp`）を実装しました（`src/app/agents/q-learning-agent.ts`）。
- コンポーネントテストを更新・追加して、オーバーレイが `MONTE_CARLO` に加え `MINIMAX` / `Q_LEARNING` 選択時にも表示されることを検証するテストケースを追加しました（`src/app/app.component.spec.ts`）。

### Testing
- 自動テストを実行して全件成功しました: `npm test -- --runInBand` が完了し、Test Suites: 11 passed, Tests: 30 passed。 
- 変更に合わせて `src/app/app.component.spec.ts` にオーバーレイ表示の検証を追加し、テストスイートはすべて通過しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964c4538888324ba8798cf40180aeb)